### PR TITLE
Init stream position to 0 for easier (de)serialization by client

### DIFF
--- a/SFTP.Wrapper/SftpManager.cs
+++ b/SFTP.Wrapper/SftpManager.cs
@@ -77,6 +77,7 @@ namespace SFTP.Wrapper
                             client.EndDownloadFile(result);
                             if (result.IsCompleted)
                             {
+                                stream.Position = 0;
                                 downloadedFileResponses.Add(new DownloadFileResponse
                                 {
                                     Stream = stream,
@@ -121,6 +122,7 @@ namespace SFTP.Wrapper
 
         public virtual async Task<ResultStatus<UploadFileResponse>> UploadFileAsync(UploadFileRequest request)
         {
+            request.StreamToUpload.Position = 0;
             var response = await HandleAsync(async (client, req) =>
             {
                 await Task.Factory.FromAsync(client.BeginUploadFile(request.StreamToUpload, request.WhereToUpload), client.EndUploadFile).ConfigureAwait(false);


### PR DESCRIPTION
Before uploading a file via stream I needed to set the stream position to 0, otherwise the uploaded filesize would be 0.
Also when downloading, setting the stream position to 0 before returning, the client can directly deserialize the stream instead of having to set position to 0 before deserialization. 